### PR TITLE
Add Makefile and README.md instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
+export GIT_COMMIT
+
+.PHONY: build
+build:
+	docker build -t mixpanel-proxy .
+
+.PHONY: tag
+tag: check-git-clean check-git-master-branch
+	docker tag mixpanel-proxy luneclimate/mixpanel-proxy
+	docker tag mixpanel-proxy luneclimate/mixpanel-proxy:$(GIT_COMMIT)
+
+
+.PHONY: push
+push: check-git-master-branch
+	docker push luneclimate/mixpanel-proxy
+	docker push luneclimate/mixpanel-proxy:$(GIT_COMMIT)
+
+# Checks if there are uncommitted changes
+.PHONY: check-git-clean
+check-git-clean:
+	@if [ "$(shell git diff-index --quiet HEAD; echo $$?)" != "0" ] ; then \
+		echo "There are uncomitted changes. Please remove or commit them."; \
+		exit 1; \
+    fi;
+
+# Checks if the current branch is master
+.PHONY: check-git-master-branch
+check-git-master-branch:
+	@if [ "$(shell git branch --show-current)" != "master" ] ; then \
+		echo "Please ensure to be operating on the master branch"; \
+		exit 1; \
+    fi;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Nginx Proxy for Mixpanel
 An example nginx config that serves as a proxy to Mixpanel's Ingestion API and JavaScript library endpoints. To learn more, visit our [Self-Hosted Tracking Docs](https://developer.mixpanel.com/docs/self-hosted-tracking).
 
+
+## Development and release
+
+### Developement
+
+1. Make changes to nginx.conf, Dockerfile or any other file.
+2. Build docker image: `make`
+3. Locally run with:  `docker run --rm -p 8081:80 mixpanel-proxy` (listens on port 8081)
+
+### Release
+
+1. Ensure you are on master and have no uncommitted changes
+2. Build docker image: `make`
+3. Tag docker image: `make tag`
+4. Publish to dockerhub: `make push`
+
+
 ## Installation
 
 There are a few ways you can use this repo to deploy a server that can be use to proxy Mixpanel API requests: one-click deploy to cloud, build a docker image, or copy and paste the nginx settings to your own nginx config file.


### PR DESCRIPTION
The Makefile allows us to build the docker image for development and
publishing.

It also enables us to tag and publish a prod-ready image.
